### PR TITLE
StatCan analysis yml files and avoiding crash when datapoints fail.

### DIFF
--- a/examples/sample-lhs/sample-lhs.yml
+++ b/examples/sample-lhs/sample-lhs.yml
@@ -11,7 +11,7 @@
   # Choices are:
   #       local : Run locally.. Good to test out runs on small batches before sending to AWS.
   #       aws_batch: use for analyses with > 1000 simulations: This is currently only available for NRCan staff.  If you would wish to make used of Amazon cloud computing, please contact us.
-  :compute_environment: local
+  :compute_environment: aws_batch
 
   # DO NOT CHANGE: AWS S3 Bucket...Must be created ahead of time. Must be a STRING.
   # H&B default bucket is '834599497928' for the btap_dev account. Only used for Amazon.
@@ -23,18 +23,18 @@
   # Set to True if you wish to build the image from scratch with the below branches fresh,
   # pulling from the most recent branches indicated below. If set to false, it will use the last version built locally or
   # on AWS. This can save time (~10minute) if set to false when you have already built the image and expect no changes.
-  :nocache: false
+  :nocache: true
 
   # Branch from https://github.com/NREL/openstudio-standards. Typically 'nrcan_prod' branch.
   # Developers or people liking to work on unstable code can use 'nrcan'
-  :os_standards_branch: 'nrcan_prod'
+  :os_standards_branch: '04e8f4947f9755ad8fc87a2cd96fe2e677125844'
 
   # Branch from https://github.com/canmet-energy/btap_costing. Typically 'nrcan_prod'
   # Developers or people liking to work on unstable code can use 'master'
-  :btap_costing_branch: 'nrcan_prod'
+  :btap_costing_branch: 'master'
 
   # DO NOT CHANGE: Openstudio Version only 3.0.1 available
-  :os_version: '3.0.1'
+  :os_version: '3.2.1'
 
   # The name of the analysis. Can be a user friendly name. This is how it will appear on your local system or on the S3
   # bucket. for example if 'example_analysis' on s3 the analysis run input/output files will be here in our s3 bucket
@@ -56,7 +56,7 @@
   :algorithm:
     :type: sampling-lhs # nsga2 , parametric
     # Select number of samples. For testing just use 10.
-    :n_samples: 10
+    :n_samples: 3000
     # Select lhs type.. see link.
     #https://scikit-optimize.github.io/stable/auto_examples/sampler/initial-sampling-method.html
     :lhs_type: classic
@@ -115,7 +115,7 @@
     #'CAN_YT_Whitehorse.Intl.AP.719640_CWEC2016.epw'
   ]
   :primary_heating_fuel: [
-      "Electricity",
+      #"Electricity",
       "NaturalGas",
     # "FuelOilNo2"
   ]
@@ -135,7 +135,7 @@
   ]
   # Is this different from the LED option?
   :daylighting_type: [ 'NECB_Default',
-                       'add_daylighting_controls'
+                       #'add_daylighting_controls'
   ]
   :ecm_system_name: [
       'NECB_Default',
@@ -146,7 +146,7 @@
       'HS13_ASHP_VRF'
   ]
 
-  :erv_package: [ 'NECB_Default',
+  :erv_package: [ #'NECB_Default',
                   "NECB_Default_All",
                   "Plate-All",
                   "Plate-Existing",
@@ -186,11 +186,11 @@
                     '0.183'
   ]
 
-  :ext_floor_cond: [ #'NECB_Default',
-                     '0.227',
-                     '0.183',
-                     '0.162',
-                     '0.142'
+  :ext_floor_cond: [ 'NECB_Default',
+                     #'0.227',
+                     #'0.183',
+                     #'0.162',
+                     #'0.142'
   ]
   :ext_roof_cond: [ #'NECB_Default',
                     '0.227',
@@ -220,34 +220,34 @@
                        #'0.210'
   ]
 
-  :door_construction_cond: [ #'NECB_Default',
-                             '2.4',
-                             '2.2',
-                             '1.6'
+  :door_construction_cond: [ 'NECB_Default',
+                             #'2.4',
+                             #'2.2',
+                             #'1.6'
   ]
   :fixed_window_cond: [ #'NECB_Default',
                         '2.4',
                         '2.2',
                         '1.6'
   ]
-  :glass_door_cond: [ #'NECB_Default',
-                      '2.4',
-                      '2.2',
-                      '1.6'
+  :glass_door_cond: [ 'NECB_Default',
+                      #'2.4',
+                      #'2.2',
+                      #'1.6'
   ]
-  :overhead_door_cond: [ #'NECB_Default',
-                         '2.4',
-                         '2.2',
-                         '1.6'
+  :overhead_door_cond: [ 'NECB_Default',
+                         #'2.4',
+                         #'2.2',
+                         #'1.6'
   ]
-  :skylight_cond: [ #'NECB_Default',
-                    '2.4',
-                    '2.2',
-                    '1.6'
+  :skylight_cond: [ 'NECB_Default',
+                    #'2.4',
+                    #'2.2',
+                    #'1.6'
   ]
   :glass_door_solar_trans: [ 'NECB_Default',
-                             '0.05',
-                             '0.95'
+                             #'0.05',
+                             #'0.95'
   ]
   :fixed_wind_solar_trans: [ #'NECB_Default',
                              '0.2',
@@ -258,9 +258,9 @@
   ]
   # This is the same as SHGC
   :skylight_solar_trans: [ 'NECB_Default',
-                           '0.05',
-                           '0.50',
-                           '0.95'
+                           #'0.05',
+                           #'0.50',
+                           #'0.95'
   ]
   :fdwr_set: [ #'NECB_Default',
                '0.1',
@@ -308,7 +308,7 @@
   :oa_scale: [ 'NECB_Default' ]
   :infiltration_scale: [ 'NECB_Default' ]
   :chiller_type: [ 'NECB_Default',
-                   'VSD'
+                   #'VSD'
   ]
   :airloop_economizer_type: [  # (1) nil/'NECB_Default' (2) 'DifferentialEnthalpy (3) 'DifferentialDryBulb'
     'NECB_Default',
@@ -317,5 +317,5 @@
   ]
   :shw_scale: [ # Options: (1) 'NECB_Default'/nil/'none'/false (i.e. do nothing), (2) a float number larger than 0.0
       'NECB_Default',
-      '0.5'
+      #'0.5'
   ]

--- a/examples/sample-lhs/sample-lhs_statcan_elec.yml
+++ b/examples/sample-lhs/sample-lhs_statcan_elec.yml
@@ -31,7 +31,7 @@
 
   # Branch from https://github.com/canmet-energy/btap_costing. Typically 'nrcan_prod'
   # Developers or people liking to work on unstable code can use 'master'
-  :btap_costing_branch: 'nrcan'
+  :btap_costing_branch: 'master'
 
   # DO NOT CHANGE: Openstudio Version only 3.0.1 available
   :os_version: '3.2.1'

--- a/examples/sample-lhs/sample-lhs_statcan_elec.yml
+++ b/examples/sample-lhs/sample-lhs_statcan_elec.yml
@@ -1,0 +1,321 @@
+---
+# Run configuration
+:analysis_configuration:
+
+  # BTAP Batch version
+  :btap_batch_version: 1.0.004
+
+  # number of threads is a stub for aws batch. Unused at the moment.
+  :no_of_threads:
+
+  # Choices are:
+  #       local : Run locally.. Good to test out runs on small batches before sending to AWS.
+  #       aws_batch: use for analyses with > 1000 simulations: This is currently only available for NRCan staff.  If you would wish to make used of Amazon cloud computing, please contact us.
+  :compute_environment: aws_batch
+
+  # DO NOT CHANGE: AWS S3 Bucket...Must be created ahead of time. Must be a STRING.
+  # H&B default bucket is '834599497928' for the btap_dev account. Only used for Amazon.
+  :s3_bucket: '834599497928'
+
+  # Use btap_public_cli for full opensource version. For btap_private_cli to use costing. Contact us if you wish to work with costing data.
+  :image_name: 'btap_private_cli'
+
+  # Set to True if you wish to build the image from scratch with the below branches fresh,
+  # pulling from the most recent branches indicated below. If set to false, it will use the last version built locally or
+  # on AWS. This can save time (~10minute) if set to false when you have already built the image and expect no changes.
+  :nocache: false
+
+  # Branch from https://github.com/NREL/openstudio-standards. Typically 'nrcan_prod' branch.
+  # Developers or people liking to work on unstable code can use 'nrcan'
+  :os_standards_branch: '04e8f4947f9755ad8fc87a2cd96fe2e677125844'
+
+  # Branch from https://github.com/canmet-energy/btap_costing. Typically 'nrcan_prod'
+  # Developers or people liking to work on unstable code can use 'master'
+  :btap_costing_branch: 'nrcan'
+
+  # DO NOT CHANGE: Openstudio Version only 3.0.1 available
+  :os_version: '3.2.1'
+
+  # The name of the analysis. Can be a user friendly name. This is how it will appear on your local system or on the S3
+  # bucket. for example if 'example_analysis' on s3 the analysis run input/output files will be here in our s3 bucket
+  # s3://834599497928/phylroy.lopez/example_analysis
+  :analysis_name: 'sample_lhs_example'
+
+  # Do you wish to run the simulations?
+  :run_annual_simulation: true
+
+  # Do you wish to enable automated costing for materials, labour, equipment? Disabled in btap_public_cli version.
+  :enable_costing: true
+
+  # DO NOT CHANGE. Will keep the postgresql running after the analysis is complete. Turn this on if you wish to monitor the
+  # results in real-time or wish to append subsequent analyses to the database. To kill the database manually type
+  # 'docker kill btap_postgres' at any command prompt on your host system.
+  :kill_database: true
+
+  ###########################################     ALGORITHM        #######################################################
+  :algorithm:
+    :type: sampling-lhs # nsga2 , parametric
+    # Select number of samples. For testing just use 10.
+    :n_samples: 3000
+    # Select lhs type.. see link.
+    #https://scikit-optimize.github.io/stable/auto_examples/sampler/initial-sampling-method.html
+    :lhs_type: classic
+    # Random seed to create consistent random numbers. Keep to 1 if not needed.
+    :random_seed: 1
+
+###########################################     Hourly Data     #######################################################
+  :output_variables: [
+    #{    key: '*',     variable: 'Zone Air Temperature',     frequency: 'hourly'}
+  ]
+  :output_meters: [
+    {    name: 'Gas:Facility',     frequency: 'hourly'},
+    {    name: 'Electricity:Facility',     frequency: 'hourly'},
+    # {    name: 'DISTRICTHEATING:FACILITY',     frequency: 'hourly'},
+    # {    name: 'DISTRICTCOOLING:FACILITY',     frequency: 'hourly'},
+    {    name: 'FuelOil#2:Facility',     frequency: 'hourly'}
+  ]
+
+#########################################  BUILDING OPTIONS  ###########################################################
+# Building options
+:building_options:
+  :building_type: [
+    #  "SecondarySchool",
+    # "PrimarySchool",
+    # "SmallOffice",
+    # "MediumOffice",
+    # "LargeOffice",
+    # "SmallHotel",
+    # "LargeHotel",
+    # "Warehouse",
+    # "RetailStandalone",
+    # "RetailStripmall",
+    # "QuickServiceRestaurant",
+      "FullServiceRestaurant",
+    # "MidriseApartment",
+    # "HighriseApartment",
+    # "LowriseApartment",
+    #"Hospital",
+    #"Outpatient"
+  ]
+  # The standard template to use for baseline assumptions.
+  :template: [
+    #  "BTAPPRE1980",
+    #  "BTAP1980TO2010",
+    #  "NECB2011",
+    #  "NECB2015",
+      "NECB2017"
+  ]
+  :epw_file: [
+      'CAN_QC_Montreal-Trudeau.Intl.AP.716270_CWEC2016.epw',
+    #'CAN_NS_Halifax.Dockyard.713280_CWEC2016.epw',
+    #'CAN_AB_Edmonton.Intl.AP.711230_CWEC2016.epw',
+    #'CAN_BC_Vancouver.Intl.AP.718920_CWEC2016.epw',
+    #'CAN_AB_Calgary.Intl.AP.718770_CWEC2016.epw',
+    #'CAN_ON_Toronto.Pearson.Intl.AP.716240_CWEC2016.epw',
+    #'CAN_YT_Whitehorse.Intl.AP.719640_CWEC2016.epw'
+  ]
+  :primary_heating_fuel: [
+      "Electricity",
+      #"NaturalGas",
+    # "FuelOilNo2"
+  ]
+  :dcv_type: [
+      #'NECB_Default',
+      'No_DCV',
+      'Occupancy_based_DCV',
+      'CO2_based_DCV'
+  ]
+  :lights_type: [
+      #'NECB_Default',
+      'LED'
+  ]
+  :lights_scale: [ 'NECB_Default',
+    # '0.5',
+    # '0.01'
+  ]
+  # Is this different from the LED option?
+  :daylighting_type: [ 'NECB_Default',
+                       #'add_daylighting_controls'
+  ]
+  :ecm_system_name: [
+      'NECB_Default',
+      'HS09_CCASHP_Baseboard',
+      'HS08_CCASHP_VRF',
+      'HS11_ASHP_PTHP',
+      'HS12_ASHP_Baseboard',
+      'HS13_ASHP_VRF'
+  ]
+
+  :erv_package: [ #'NECB_Default',
+                  "NECB_Default_All",
+                  "Plate-All",
+                  "Plate-Existing",
+                  "Rotary-All",
+                  "Rotary-Existing"
+  ]
+  # What are the existing vs all versions?
+  :boiler_eff: [
+      "NECB_Default",
+      #"NECB 85% Efficient Condensing Boiler",
+      #"NECB 88% Efficient Condensing Boiler",
+      #"NECB 91% Efficient Condensing Boiler",
+      #"NECB 94% Efficient Condensing Boiler",
+      #"Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler"
+  ]
+  :furnace_eff: [
+      "NECB_Default",
+      #"NECB 85% Efficient Condensing Gas Furnace",
+      #"NECB 88% Efficient Condensing Gas Furnace",
+      #"NECB 91% Efficient Condensing Gas Furnace",
+      #"NECB 94% Efficient Condensing Gas Furnace"
+  ]
+  :shw_eff: [
+      "NECB_Default",
+      #"Natural Gas 85% Efficient SHW",
+      #"Natural Gas 88% Efficient SHW",
+      #"Natural Gas Direct Vent with Electric Ignition",
+      #"Natural Gas Power Vent with Electric Ignition",
+      #"Natural Gas Power Vent with Electric Ignition 97% Efficient"
+  ]
+  # Default DHW is consistent with primary heating fuel
+  :ext_wall_cond: [ #'NECB_Default',
+                    '0.314',
+                    '0.278',
+                    '0.247',
+                    '0.210',
+                    '0.183'
+  ]
+
+  :ext_floor_cond: [ 'NECB_Default',
+                     #'0.227',
+                     #'0.183',
+                     #'0.162',
+                     #'0.142'
+  ]
+  :ext_roof_cond: [ #'NECB_Default',
+                    '0.227',
+                    '0.193',
+                    '0.183',
+                    '0.162',
+                    '0.142',
+                    '0.138',
+                    '0.121'
+  ]
+  :ground_wall_cond: [ 'NECB_Default',
+                       #'0.568',
+                       #'0.379',
+                       #'0.284',
+                       #'0.210'
+  ]
+
+  :ground_floor_cond: [ 'NECB_Default',
+                        #'0.758',
+                        #'0.379'
+  ]
+
+  :ground_roof_cond: [ 'NECB_Default',
+                       #'0.568',
+                       #'0.379' ,
+                       #'0.284',
+                       #'0.210'
+  ]
+
+  :door_construction_cond: [ 'NECB_Default',
+                             #'2.4',
+                             #'2.2',
+                             #'1.6'
+  ]
+  :fixed_window_cond: [ #'NECB_Default',
+                        '2.4',
+                        '2.2',
+                        '1.6'
+  ]
+  :glass_door_cond: [ 'NECB_Default',
+                      #'2.4',
+                      #'2.2',
+                      #'1.6'
+  ]
+  :overhead_door_cond: [ 'NECB_Default',
+                         #'2.4',
+                         #'2.2',
+                         #'1.6'
+  ]
+  :skylight_cond: [ 'NECB_Default',
+                    #'2.4',
+                    #'2.2',
+                    #'1.6'
+  ]
+  :glass_door_solar_trans: [ 'NECB_Default',
+                             #'0.05',
+                             #'0.95'
+  ]
+  :fixed_wind_solar_trans: [ #'NECB_Default',
+                             '0.2',
+                             '0.3',
+                             '0.4',
+                             '0.5',
+                             '0.6'
+  ]
+  # This is the same as SHGC
+  :skylight_solar_trans: [ 'NECB_Default',
+                           #'0.05',
+                           #'0.50',
+                           #'0.95'
+  ]
+  :fdwr_set: [ #'NECB_Default',
+               '0.1',
+               '0.2',
+               '0.3',
+               '0.4',
+               '0.5',
+               '0.6',
+               '0.7',
+               '0.8',
+               '0.9'
+  ]
+
+  :srr_set: [ 'NECB_Default',
+              #'0.03',
+              #'0.05',
+              #'0.08',
+              #'0.10',
+  ]
+  :rotation_degrees: [ #'NECB_Default',
+                       '0.0',
+                       '45.0',
+                       '90.0'
+  ]
+  # Picking the worst orientation (major axis of building oriented N-S)
+  :scale_x: [ '1.0' ]
+  :scale_y: [ '1.0' ]
+  :scale_z: [ '1.0' ]
+  :pv_ground_type: [ 'NECB_Default', 'add_pv_ground' ]
+  :pv_ground_total_area_pv_panels_m2: [ 'NECB_Default' ]
+  :pv_ground_tilt_angle: [ 'NECB_Default' ]
+  :pv_ground_azimuth_angle: [ 'NECB_Default' ]
+  :pv_ground_module_description: [ 'NECB_Default' ]
+  :adv_dx_units: [ 'NECB_Default',
+                   #'Carrier WeatherExpert'
+  ]
+  :nv_type: [ 'NECB_Default',
+              'add_nv'
+  ]
+  :nv_opening_fraction: [ 'NECB_Default' ]
+  :nv_temp_out_min: [ 'NECB_Default' ]
+  :nv_delta_temp_in_out: [ 'NECB_Default' ]
+  :occupancy_loads_scale: [ 'NECB_Default' ]
+  :electrical_loads_scale: [ 'NECB_Default' ]
+  :oa_scale: [ 'NECB_Default' ]
+  :infiltration_scale: [ 'NECB_Default' ]
+  :chiller_type: [ 'NECB_Default',
+                   #'VSD'
+  ]
+  :airloop_economizer_type: [  # (1) nil/'NECB_Default' (2) 'DifferentialEnthalpy (3) 'DifferentialDryBulb'
+    'NECB_Default',
+    'DifferentialEnthalpy',
+    'DifferentialDryBulb'
+  ]
+  :shw_scale: [ # Options: (1) 'NECB_Default'/nil/'none'/false (i.e. do nothing), (2) a float number larger than 0.0
+      'NECB_Default',
+      #'0.5'
+  ]

--- a/examples/sample-lhs/sample-lhs_statcan_elec.yml
+++ b/examples/sample-lhs/sample-lhs_statcan_elec.yml
@@ -23,7 +23,7 @@
   # Set to True if you wish to build the image from scratch with the below branches fresh,
   # pulling from the most recent branches indicated below. If set to false, it will use the last version built locally or
   # on AWS. This can save time (~10minute) if set to false when you have already built the image and expect no changes.
-  :nocache: false
+  :nocache: true
 
   # Branch from https://github.com/NREL/openstudio-standards. Typically 'nrcan_prod' branch.
   # Developers or people liking to work on unstable code can use 'nrcan'

--- a/examples/sample-lhs/sample-lhs_statcan_gas.yml
+++ b/examples/sample-lhs/sample-lhs_statcan_gas.yml
@@ -31,7 +31,7 @@
 
   # Branch from https://github.com/canmet-energy/btap_costing. Typically 'nrcan_prod'
   # Developers or people liking to work on unstable code can use 'master'
-  :btap_costing_branch: 'nrcan'
+  :btap_costing_branch: 'master'
 
   # DO NOT CHANGE: Openstudio Version only 3.0.1 available
   :os_version: '3.2.1'

--- a/examples/sample-lhs/sample-lhs_statcan_gas.yml
+++ b/examples/sample-lhs/sample-lhs_statcan_gas.yml
@@ -1,0 +1,321 @@
+---
+# Run configuration
+:analysis_configuration:
+
+  # BTAP Batch version
+  :btap_batch_version: 1.0.004
+
+  # number of threads is a stub for aws batch. Unused at the moment.
+  :no_of_threads:
+
+  # Choices are:
+  #       local : Run locally.. Good to test out runs on small batches before sending to AWS.
+  #       aws_batch: use for analyses with > 1000 simulations: This is currently only available for NRCan staff.  If you would wish to make used of Amazon cloud computing, please contact us.
+  :compute_environment: aws_batch
+
+  # DO NOT CHANGE: AWS S3 Bucket...Must be created ahead of time. Must be a STRING.
+  # H&B default bucket is '834599497928' for the btap_dev account. Only used for Amazon.
+  :s3_bucket: '834599497928'
+
+  # Use btap_public_cli for full opensource version. For btap_private_cli to use costing. Contact us if you wish to work with costing data.
+  :image_name: 'btap_private_cli'
+
+  # Set to True if you wish to build the image from scratch with the below branches fresh,
+  # pulling from the most recent branches indicated below. If set to false, it will use the last version built locally or
+  # on AWS. This can save time (~10minute) if set to false when you have already built the image and expect no changes.
+  :nocache: false
+
+  # Branch from https://github.com/NREL/openstudio-standards. Typically 'nrcan_prod' branch.
+  # Developers or people liking to work on unstable code can use 'nrcan'
+  :os_standards_branch: '04e8f4947f9755ad8fc87a2cd96fe2e677125844'
+
+  # Branch from https://github.com/canmet-energy/btap_costing. Typically 'nrcan_prod'
+  # Developers or people liking to work on unstable code can use 'master'
+  :btap_costing_branch: 'nrcan'
+
+  # DO NOT CHANGE: Openstudio Version only 3.0.1 available
+  :os_version: '3.2.1'
+
+  # The name of the analysis. Can be a user friendly name. This is how it will appear on your local system or on the S3
+  # bucket. for example if 'example_analysis' on s3 the analysis run input/output files will be here in our s3 bucket
+  # s3://834599497928/phylroy.lopez/example_analysis
+  :analysis_name: 'sample_lhs_example'
+
+  # Do you wish to run the simulations?
+  :run_annual_simulation: true
+
+  # Do you wish to enable automated costing for materials, labour, equipment? Disabled in btap_public_cli version.
+  :enable_costing: true
+
+  # DO NOT CHANGE. Will keep the postgresql running after the analysis is complete. Turn this on if you wish to monitor the
+  # results in real-time or wish to append subsequent analyses to the database. To kill the database manually type
+  # 'docker kill btap_postgres' at any command prompt on your host system.
+  :kill_database: true
+
+  ###########################################     ALGORITHM        #######################################################
+  :algorithm:
+    :type: sampling-lhs # nsga2 , parametric
+    # Select number of samples. For testing just use 10.
+    :n_samples: 3000
+    # Select lhs type.. see link.
+    #https://scikit-optimize.github.io/stable/auto_examples/sampler/initial-sampling-method.html
+    :lhs_type: classic
+    # Random seed to create consistent random numbers. Keep to 1 if not needed.
+    :random_seed: 1
+
+###########################################     Hourly Data     #######################################################
+  :output_variables: [
+    #{    key: '*',     variable: 'Zone Air Temperature',     frequency: 'hourly'}
+  ]
+  :output_meters: [
+    {    name: 'Gas:Facility',     frequency: 'hourly'},
+    {    name: 'Electricity:Facility',     frequency: 'hourly'},
+    # {    name: 'DISTRICTHEATING:FACILITY',     frequency: 'hourly'},
+    # {    name: 'DISTRICTCOOLING:FACILITY',     frequency: 'hourly'},
+    {    name: 'FuelOil#2:Facility',     frequency: 'hourly'}
+  ]
+
+#########################################  BUILDING OPTIONS  ###########################################################
+# Building options
+:building_options:
+  :building_type: [
+    #  "SecondarySchool",
+    # "PrimarySchool",
+    # "SmallOffice",
+    # "MediumOffice",
+    # "LargeOffice",
+    # "SmallHotel",
+    # "LargeHotel",
+    # "Warehouse",
+    # "RetailStandalone",
+    # "RetailStripmall",
+    # "QuickServiceRestaurant",
+      "FullServiceRestaurant",
+    # "MidriseApartment",
+    # "HighriseApartment",
+    # "LowriseApartment",
+    #"Hospital",
+    #"Outpatient"
+  ]
+  # The standard template to use for baseline assumptions.
+  :template: [
+    #  "BTAPPRE1980",
+    #  "BTAP1980TO2010",
+    #  "NECB2011",
+    #  "NECB2015",
+      "NECB2017"
+  ]
+  :epw_file: [
+      'CAN_QC_Montreal-Trudeau.Intl.AP.716270_CWEC2016.epw',
+    #'CAN_NS_Halifax.Dockyard.713280_CWEC2016.epw',
+    #'CAN_AB_Edmonton.Intl.AP.711230_CWEC2016.epw',
+    #'CAN_BC_Vancouver.Intl.AP.718920_CWEC2016.epw',
+    #'CAN_AB_Calgary.Intl.AP.718770_CWEC2016.epw',
+    #'CAN_ON_Toronto.Pearson.Intl.AP.716240_CWEC2016.epw',
+    #'CAN_YT_Whitehorse.Intl.AP.719640_CWEC2016.epw'
+  ]
+  :primary_heating_fuel: [
+      #"Electricity",
+      "NaturalGas",
+    # "FuelOilNo2"
+  ]
+  :dcv_type: [
+      #'NECB_Default',
+      'No_DCV',
+      'Occupancy_based_DCV',
+      'CO2_based_DCV'
+  ]
+  :lights_type: [
+      #'NECB_Default',
+      'LED'
+  ]
+  :lights_scale: [ 'NECB_Default',
+    # '0.5',
+    # '0.01'
+  ]
+  # Is this different from the LED option?
+  :daylighting_type: [ 'NECB_Default',
+                       #'add_daylighting_controls'
+  ]
+  :ecm_system_name: [
+      'NECB_Default',
+      'HS09_CCASHP_Baseboard',
+      'HS08_CCASHP_VRF',
+      'HS11_ASHP_PTHP',
+      'HS12_ASHP_Baseboard',
+      'HS13_ASHP_VRF'
+  ]
+
+  :erv_package: [ #'NECB_Default',
+                  "NECB_Default_All",
+                  "Plate-All",
+                  "Plate-Existing",
+                  "Rotary-All",
+                  "Rotary-Existing"
+  ]
+  # What are the existing vs all versions?
+  :boiler_eff: [
+      "NECB_Default",
+      "NECB 85% Efficient Condensing Boiler",
+      "NECB 88% Efficient Condensing Boiler",
+      "NECB 91% Efficient Condensing Boiler",
+      "NECB 94% Efficient Condensing Boiler",
+      "Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler"
+  ]
+  :furnace_eff: [
+      "NECB_Default",
+      "NECB 85% Efficient Condensing Gas Furnace",
+      "NECB 88% Efficient Condensing Gas Furnace",
+      "NECB 91% Efficient Condensing Gas Furnace",
+      "NECB 94% Efficient Condensing Gas Furnace"
+  ]
+  :shw_eff: [
+      "NECB_Default",
+      "Natural Gas 85% Efficient SHW",
+      "Natural Gas 88% Efficient SHW",
+      "Natural Gas Direct Vent with Electric Ignition",
+      "Natural Gas Power Vent with Electric Ignition",
+      "Natural Gas Power Vent with Electric Ignition 97% Efficient"
+  ]
+  # Default DHW is consistent with primary heating fuel
+  :ext_wall_cond: [ #'NECB_Default',
+                    '0.314',
+                    '0.278',
+                    '0.247',
+                    '0.210',
+                    '0.183'
+  ]
+
+  :ext_floor_cond: [ 'NECB_Default',
+                     #'0.227',
+                     #'0.183',
+                     #'0.162',
+                     #'0.142'
+  ]
+  :ext_roof_cond: [ #'NECB_Default',
+                    '0.227',
+                    '0.193',
+                    '0.183',
+                    '0.162',
+                    '0.142',
+                    '0.138',
+                    '0.121'
+  ]
+  :ground_wall_cond: [ 'NECB_Default',
+                       #'0.568',
+                       #'0.379',
+                       #'0.284',
+                       #'0.210'
+  ]
+
+  :ground_floor_cond: [ 'NECB_Default',
+                        #'0.758',
+                        #'0.379'
+  ]
+
+  :ground_roof_cond: [ 'NECB_Default',
+                       #'0.568',
+                       #'0.379' ,
+                       #'0.284',
+                       #'0.210'
+  ]
+
+  :door_construction_cond: [ 'NECB_Default',
+                             #'2.4',
+                             #'2.2',
+                             #'1.6'
+  ]
+  :fixed_window_cond: [ #'NECB_Default',
+                        '2.4',
+                        '2.2',
+                        '1.6'
+  ]
+  :glass_door_cond: [ 'NECB_Default',
+                      #'2.4',
+                      #'2.2',
+                      #'1.6'
+  ]
+  :overhead_door_cond: [ 'NECB_Default',
+                         #'2.4',
+                         #'2.2',
+                         #'1.6'
+  ]
+  :skylight_cond: [ 'NECB_Default',
+                    #'2.4',
+                    #'2.2',
+                    #'1.6'
+  ]
+  :glass_door_solar_trans: [ 'NECB_Default',
+                             #'0.05',
+                             #'0.95'
+  ]
+  :fixed_wind_solar_trans: [ #'NECB_Default',
+                             '0.2',
+                             '0.3',
+                             '0.4',
+                             '0.5',
+                             '0.6'
+  ]
+  # This is the same as SHGC
+  :skylight_solar_trans: [ 'NECB_Default',
+                           #'0.05',
+                           #'0.50',
+                           #'0.95'
+  ]
+  :fdwr_set: [ #'NECB_Default',
+               '0.1',
+               '0.2',
+               '0.3',
+               '0.4',
+               '0.5',
+               '0.6',
+               '0.7',
+               '0.8',
+               '0.9'
+  ]
+
+  :srr_set: [ 'NECB_Default',
+              #'0.03',
+              #'0.05',
+              #'0.08',
+              #'0.10',
+  ]
+  :rotation_degrees: [ #'NECB_Default',
+                       '0.0',
+                       '45.0',
+                       '90.0'
+  ]
+  # Picking the worst orientation (major axis of building oriented N-S)
+  :scale_x: [ '1.0' ]
+  :scale_y: [ '1.0' ]
+  :scale_z: [ '1.0' ]
+  :pv_ground_type: [ 'NECB_Default', 'add_pv_ground' ]
+  :pv_ground_total_area_pv_panels_m2: [ 'NECB_Default' ]
+  :pv_ground_tilt_angle: [ 'NECB_Default' ]
+  :pv_ground_azimuth_angle: [ 'NECB_Default' ]
+  :pv_ground_module_description: [ 'NECB_Default' ]
+  :adv_dx_units: [ 'NECB_Default',
+                   #'Carrier WeatherExpert'
+  ]
+  :nv_type: [ 'NECB_Default',
+              'add_nv'
+  ]
+  :nv_opening_fraction: [ 'NECB_Default' ]
+  :nv_temp_out_min: [ 'NECB_Default' ]
+  :nv_delta_temp_in_out: [ 'NECB_Default' ]
+  :occupancy_loads_scale: [ 'NECB_Default' ]
+  :electrical_loads_scale: [ 'NECB_Default' ]
+  :oa_scale: [ 'NECB_Default' ]
+  :infiltration_scale: [ 'NECB_Default' ]
+  :chiller_type: [ 'NECB_Default',
+                   #'VSD'
+  ]
+  :airloop_economizer_type: [  # (1) nil/'NECB_Default' (2) 'DifferentialEnthalpy (3) 'DifferentialDryBulb'
+    'NECB_Default',
+    'DifferentialEnthalpy',
+    'DifferentialDryBulb'
+  ]
+  :shw_scale: [ # Options: (1) 'NECB_Default'/nil/'none'/false (i.e. do nothing), (2) a float number larger than 0.0
+      'NECB_Default',
+      #'0.5'
+  ]

--- a/examples/sample-lhs/sample-lhs_statcan_gas.yml
+++ b/examples/sample-lhs/sample-lhs_statcan_gas.yml
@@ -23,7 +23,7 @@
   # Set to True if you wish to build the image from scratch with the below branches fresh,
   # pulling from the most recent branches indicated below. If set to false, it will use the last version built locally or
   # on AWS. This can save time (~10minute) if set to false when you have already built the image and expect no changes.
-  :nocache: false
+  :nocache: true
 
   # Branch from https://github.com/NREL/openstudio-standards. Typically 'nrcan_prod' branch.
   # Developers or people liking to work on unstable code can use 'nrcan'

--- a/src/btap_batch.py
+++ b/src/btap_batch.py
@@ -2367,7 +2367,9 @@ class PostProcessResults:
                 if row['datapoint_output_url'].startswith('file:///'):
                     # This is a local file. use system copy. First remove prefix
                     local_file_path = os.path.join(row['datapoint_output_url'][len('file:///'):], file_path)
-                    shutil.copyfile(local_file_path, os.path.join(bin_folder, row[':datapoint_id'] + extension))
+                    if os.path.isfile(local_file_path):
+                        shutil.copyfile(local_file_path, os.path.join(bin_folder, row[':datapoint_id'] + extension))
+                    #shutil.copyfile(local_file_path, os.path.join(bin_folder, row[':datapoint_id'] + extension))
                 elif row['datapoint_output_url'].startswith('https://s3'):
                     p = re.compile(
                         "https:\/\/s3\.console\.aws\.amazon\.com\/s3\/buckets\/(\d*)\?region=(.*)\&prefix=(.*)")

--- a/utilities/generate_hourly_table.py
+++ b/utilities/generate_hourly_table.py
@@ -1,0 +1,45 @@
+# This script should be placed in the hourly.csv directory of the results directory of a btap_batch run.  It will go
+# through the hourly results csv for each datapoint in the folder and collect them all into one csv file called
+# 'total_hourly_res.csv'.  The 'tatal_hourly_res.csv' file is saved in the same directory as the individual hourly
+# results files.
+
+import os
+
+# Get the output directory and the location of the output file
+curr_dir = os.getcwd()
+output_file = os.path.join(curr_dir, "total_hourly_res.csv")
+
+# Initilalize the output list
+concat_data = []
+
+# first_read is used to determine weather or not to write the header to the output file
+first_read = True
+
+# Go through all of the objects in the output folder
+for file_object in os.listdir(curr_dir):
+    # Set the absolute location of the current file object we are looking at
+    datapoint = os.path.join(curr_dir, file_object)
+    # Check if it is a file
+    if os.path.isfile(datapoint):
+        # If it is a file check if it is a csv file
+        if str(datapoint).lower().endswith('.csv'):
+            # If it is a csv file make sure it is not the output file
+            if str(datapoint).lower() != "total_hourly_res.csv":
+                # Open the file and add it to the concat_data list which collects the hourly data from all of the files
+                with open(datapoint) as f:
+                    lines = f.readlines()
+                    line_num = 0
+                    # If this is the first time looking at a file add the header data to the output list, otherwise don't
+                    for line in lines:
+                        if first_read and line_num == 0:
+                            concat_data.append(line)
+                            first_read = False
+                        if line_num > 0:
+                            concat_data.append(line)
+                        line_num += 1
+
+# Write the hourly data list to the output file
+f_out = open(output_file, 'w')
+for out_line in concat_data:
+    f_out.write(out_line)
+f_out.close()


### PR DESCRIPTION
Including updated sample-lhs.yml files for gas and electric StatCan analyses.  Modified btap_batch.py so that it avoids trying to copy files that don't exist thus not crashing prior to generating the output.xlsx file.  Added a new python script to the utilities folder which combines the hourly results in the hourly.csv folder in the results folder into one large csv containing all of the hourly results for an analysis.