### PR TITLE
Including fix for gem issues when running using btap_batch locally on a computer connected to the NRCan network

### DIFF
--- a/bin/btap_batch.py
+++ b/bin/btap_batch.py
@@ -83,6 +83,7 @@ def build(**kwargs):
     os.environ['BUILD_ENV_NAME'] = config['build_env_name']
     os.environ['GIT_API_TOKEN'] = config['git_api_token']
     compute_environment = config['compute_environment']
+    local_nrcan = config['local_nrcan']
 
 
     if disable_costing:
@@ -96,7 +97,8 @@ def build(**kwargs):
                                        weather_list=weather_list,
                                        os_standards_branch=os_standards_branch,
                                        build_btap_batch=build_btap_batch,
-                                       build_btap_cli=build_btap_cli)
+                                       build_btap_cli=build_btap_cli,
+                                       local_nrcan=local_nrcan)
 
 
 

--- a/schemas/build_config_schema.yml
+++ b/schemas/build_config_schema.yml
@@ -108,6 +108,7 @@ required:
   - build_btap_cli
   - build_btap_batch
   - disable_costing
+  - local_nrcan
   - compute_environment
 additionalProperties: false
 

--- a/schemas/build_config_schema.yml
+++ b/schemas/build_config_schema.yml
@@ -79,6 +79,12 @@ properties:
     type: boolean
     default: true
 
+  local_nrcan:
+    description: "**NRCan only** Set this to True if you intend to build your environment locally on a computer connected to 
+    the NRCan network.  Otherwise leave it as False."
+    type: boolean
+    default: false
+
   compute_environment:
     description: "Select which environment to build and where to run analyses.\n\n 
     **local**: will use docker on your local computer.\n\n

--- a/src/Dockerfiles/btap_cli/Dockerfile
+++ b/src/Dockerfiles/btap_cli/Dockerfile
@@ -6,6 +6,7 @@ ARG OPENSTUDIO_VERSION
 ARG BTAP_COSTING_BRANCH=''
 ARG OS_STANDARDS_BRANCH='nrcan'
 ARG WEATHER_FILES=''
+ARG LOCALNRCAN=''
 
 
 # Git api token secret. Do not share as a ENV.
@@ -21,6 +22,13 @@ USER  root
 
 #Be root and install btap_costing under the root folder.
 WORKDIR /
+RUN if [ -z "$LOCALNRCAN" ] ; then \
+      echo "Cloning install_nrcan_certs repository" \
+      && git clone https://$GIT_API_TOKEN:x-oauth-basic@github.com/canmet-energy/linux_nrcan_certs.git --depth 1 --branch main --single-branch /btap_costing \
+      && cd /linux_nrcan_certs \
+      && sudo install_nrcan_certs.sh; \
+    fi
+
 # if costing branch name is undefined.. do not use costing.
 RUN if [ -z "$BTAP_COSTING_BRANCH" ] ; then \
         echo "Creating Public CLI witout costing" \

--- a/src/Dockerfiles/btap_cli/Dockerfile
+++ b/src/Dockerfiles/btap_cli/Dockerfile
@@ -7,6 +7,7 @@ ARG BTAP_COSTING_BRANCH=''
 ARG OS_STANDARDS_BRANCH='nrcan'
 ARG WEATHER_FILES=''
 ARG LOCALNRCAN=''
+ARG LOCALNRCAN_BRANCH='main'
 
 
 # Git api token secret. Do not share as a ENV.
@@ -22,11 +23,12 @@ USER  root
 
 #Be root and install nrcan_certs under the root folder if LOCALNRCAN is set.
 WORKDIR /
-RUN if [ -z "$LOCALNRCAN" ] ; then \
+RUN if [ ! -z "$LOCALNRCAN" ] ; then \
       echo "Cloning install_nrcan_certs repository" \
-      && git clone https://$GIT_API_TOKEN:x-oauth-basic@github.com/canmet-energy/linux_nrcan_certs.git --depth 1 --branch 'main' --single-branch /linux_nrcan_certs \
+      && git clone https://$GIT_API_TOKEN:x-oauth-basic@github.com/canmet-energy/linux_nrcan_certs.git --depth 1 --branch ${LOCALNRCAN_BRANCH} --single-branch /linux_nrcan_certs \
       && cd /linux_nrcan_certs \
-      && /install_nrcan_certs.sh;\
+      && ./install_nrcan_certs.sh \
+      && git rev-parse --short HEAD;\
     fi
 
 #Be root and install btap_costing under the root folder.
@@ -49,7 +51,7 @@ RUN if [ ! -z "$BTAP_COSTING_BRANCH" ] ; then \
         && cd /btap_costing \
         && sed -i '/^.*standards.*$/d' Gemfile \
         && echo "gem 'openstudio-standards', :github => 'NREL/openstudio-standards', :branch => '${OS_STANDARDS_BRANCH}'" | tee -a Gemfile \
-        #&& bundle install \
+        && bundle install \
         && echo 'standards revision' \
         && git rev-parse --short HEAD;\
     fi

--- a/src/Dockerfiles/btap_cli/Dockerfile
+++ b/src/Dockerfiles/btap_cli/Dockerfile
@@ -20,14 +20,17 @@ ENV DISPLAY ${DISPLAY}
 ENV RUBYLIB=/usr/local/openstudio-${OPENSTUDIO_VERSION}/Ruby:/usr/Ruby
 USER  root
 
-#Be root and install btap_costing under the root folder.
+#Be root and install nrcan_certs under the root folder if LOCALNRCAN is set.
 WORKDIR /
 RUN if [ -z "$LOCALNRCAN" ] ; then \
       echo "Cloning install_nrcan_certs repository" \
-      && git clone https://$GIT_API_TOKEN:x-oauth-basic@github.com/canmet-energy/linux_nrcan_certs.git --depth 1 --branch main --single-branch /btap_costing \
+      && git clone https://$GIT_API_TOKEN:x-oauth-basic@github.com/canmet-energy/linux_nrcan_certs.git --depth 1 --branch 'main' --single-branch /linux_nrcan_certs \
       && cd /linux_nrcan_certs \
-      && sudo install_nrcan_certs.sh; \
+      && /install_nrcan_certs.sh;\
     fi
+
+#Be root and install btap_costing under the root folder.
+WORKDIR /
 
 # if costing branch name is undefined.. do not use costing.
 RUN if [ -z "$BTAP_COSTING_BRANCH" ] ; then \
@@ -38,6 +41,7 @@ RUN if [ -z "$BTAP_COSTING_BRANCH" ] ; then \
         && echo 'standards revision' \
         && git rev-parse --short HEAD;\
     fi
+
 # if costing branch name is defined.. use costing.
 RUN if [ ! -z "$BTAP_COSTING_BRANCH" ] ; then \
         echo "Creating Private CLI with Costing" \
@@ -45,7 +49,7 @@ RUN if [ ! -z "$BTAP_COSTING_BRANCH" ] ; then \
         && cd /btap_costing \
         && sed -i '/^.*standards.*$/d' Gemfile \
         && echo "gem 'openstudio-standards', :github => 'NREL/openstudio-standards', :branch => '${OS_STANDARDS_BRANCH}'" | tee -a Gemfile \
-        && bundle install \
+        #&& bundle install \
         && echo 'standards revision' \
         && git rev-parse --short HEAD;\
     fi

--- a/src/btap/cli_helper_methods.py
+++ b/src/btap/cli_helper_methods.py
@@ -226,7 +226,7 @@ def build_and_configure_docker_and_aws(btap_batch_branch=None,
         # Add local_nrcan argument to build_args_btap_cli dictionary.  This argument is only used when building a
         # btap_cli image locally
         if local_nrcan:
-            build_args_btap_cli["LOCALNRCAN"] = local_nrcan
+            build_args_btap_cli["LOCALNRCAN"] = str(local_nrcan)
 
         image_worker = DockerImageManager(image_name='btap_cli')
         if build_btap_cli:

--- a/src/btap/cli_helper_methods.py
+++ b/src/btap/cli_helper_methods.py
@@ -743,6 +743,10 @@ build_btap_cli: True
 # Rebuild btap_batch image
 build_btap_batch: True
 
+# Set this to True if you intend to build your environment locally on a computer connected to the NRCan network.
+# Otherwise leave it as False.
+local_nrcan: False
+
     """
 
     output_file = Path(build_config_path)

--- a/src/btap/cli_helper_methods.py
+++ b/src/btap/cli_helper_methods.py
@@ -154,7 +154,8 @@ def build_and_configure_docker_and_aws(btap_batch_branch=None,
                                        os_standards_branch=None,
                                        build_btap_cli=None,
                                        build_btap_batch=None,
-                                       weather_list=None):
+                                       weather_list=None,
+                                       local_nrcan=None):
 
 
 
@@ -164,7 +165,8 @@ def build_and_configure_docker_and_aws(btap_batch_branch=None,
     build_args_btap_cli = {'OPENSTUDIO_VERSION': openstudio_version,
                            'BTAP_COSTING_BRANCH': btap_costing_branch,
                            'OS_STANDARDS_BRANCH': os_standards_branch,
-                           'WEATHER_FILES': weather_locations}
+                           'WEATHER_FILES': weather_locations,
+                           'LOCALNRCAN': ''}
     # build args for btap_batch container.
     build_args_btap_batch = {'BTAP_BATCH_BRANCH': btap_batch_branch}
 
@@ -221,6 +223,11 @@ def build_and_configure_docker_and_aws(btap_batch_branch=None,
 
     if compute_environment in ['local']:
         # Build btap_cli image
+        # Add local_nrcan argument to build_args_btap_cli dictionary.  This argument is only used when building a
+        # btap_cli image locally
+        if local_nrcan:
+            build_args_btap_cli["LOCALNRCAN"] = local_nrcan
+
         image_worker = DockerImageManager(image_name='btap_cli')
         if build_btap_cli:
             print('Building btap_cli image')


### PR DESCRIPTION
The issue was because the btap_cli image was not created including the nrcan cert files.  This resulted in gems being pulled from the http version of the rubygems.  I don't know why but this caused incorrect versions of the gems to be downloaded and used.  In any case, including the nrcan cert in the Docker images resolved the issue.  I added the "local_nrcan" argument to the build_config.yml file.  The user should set it to True if the environment is being built locally on a computer connected to the nrcan network.  Otherwise it should be left as False.